### PR TITLE
Update image resize focus options

### DIFF
--- a/src/File/ImageOptions.php
+++ b/src/File/ImageOptions.php
@@ -100,7 +100,13 @@ class ImageOptions implements UrlOptionsInterface
         if (\null !== $this->resizeFit) {
             $options['fit'] = $this->resizeFit;
 
-            if ('thumb' === $this->resizeFit && \null !== $this->resizeFocus) {
+            if ( (
+                    'pad' === $this->resizeFit ||
+                    'fill' === $this->resizeFit ||
+                    'crop' === $this->resizeFit ||
+                    'thumb' === $this->resizeFit
+                )
+                && \null !== $this->resizeFocus) {
                 $options['f'] = $this->resizeFocus;
             }
             if ('pad' === $this->resizeFit && \null !== $this->backgroundColor) {

--- a/src/File/ImageOptions.php
+++ b/src/File/ImageOptions.php
@@ -308,6 +308,7 @@ class ImageOptions implements UrlOptionsInterface
             'top_left',
             'bottom_right',
             'bottom_left',
+            'center'
         ];
 
         if (\null !== $resizeFocus && !\in_array($resizeFocus, $validValues, \true)) {


### PR DESCRIPTION
According to the documentation, the resizeFocus option 'center' can be passed: https://www.contentful.com/developers/docs/references/images-api/#/reference/resizing-&-cropping/specify-focus-area

Also, when setting the QueryString options, the resizeFit options 'pad', 'fill' and 'crop' were never considered but should have been according to the same link.

Let me know if anything isn't ok to merge this PR. Thank you.