### PR TITLE
Add execption handler for guzzle_json_decode

### DIFF
--- a/src/Api/Requester.php
+++ b/src/Api/Requester.php
@@ -13,6 +13,7 @@ namespace Contentful\Core\Api;
 
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
+use InvalidArgumentException;
 use function GuzzleHttp\json_decode as guzzle_json_decode;
 use Psr\Http\Message\RequestInterface;
 
@@ -82,8 +83,12 @@ class Requester
         $errorId = '';
         $response = $exception->getResponse();
         if ($response) {
-            $data = guzzle_json_decode((string) $response->getBody(), true);
-            $errorId = (string) $data['sys']['id'] ?? '';
+            try {
+                $data = guzzle_json_decode((string) $response->getBody(), true);
+                $errorId = (string) $data['sys']['id'] ?? '';
+            } catch (InvalidArgumentException $invalidArgumentException) {
+                $errorId = 'InvalidResponseBody';
+            }
         }
 
         $exceptionClass = $this->getExceptionClass($errorId);

--- a/src/Exception/InvalidResponseBodyException.php
+++ b/src/Exception/InvalidResponseBodyException.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * This file is part of the contentful/contentful-core package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Contentful\Core\Exception;
+
+use Contentful\Core\Api\Exception;
+
+/**
+ * A InvalidResponseBodyException indicates that there was problem with response body.
+ */
+class InvalidResponseBodyException extends Exception
+{
+}


### PR DESCRIPTION
If request fails - `\Contentful\Core\Api\Requester::createCustomException` is called, which assumes that response body will always be valid JSON string - but unfortunately in rare cases it isn't. Invalid response body passed to `guzzle_json_decode` results in `InvalidArgumentException` witch MUST be caught otherwise it propagates up the frame and source of original exception no longer can be determined.

This Pull Request adds additional exception handling for cases when `guzzle_json_decode` fails and adds additional exception class for such cases.