### PR TITLE
add ability to clear client message store, and not store messages

### DIFF
--- a/src/Api/BaseClient.php
+++ b/src/Api/BaseClient.php
@@ -54,15 +54,22 @@ abstract class BaseClient implements ClientInterface
     private $messages = [];
 
     /**
+     * @var bool
+     */
+    private $storeMessages = true;
+
+    /**
      * Client constructor.
      */
     public function __construct(
         string $accessToken,
         string $host,
         LoggerInterface $logger = null,
-        HttpClient $httpClient = null
+        HttpClient $httpClient = null,
+        bool $storeMessages = true
     ) {
         $this->logger = $logger ?: new NullLogger();
+        $this->storeMessages = $storeMessages;
         $this->requester = new Requester(
             $httpClient ?: new HttpClient(),
             $this->getApi(),
@@ -101,7 +108,9 @@ abstract class BaseClient implements ClientInterface
         $request = $this->requestBuilder->build($method, $uri, $options);
 
         $message = $this->requester->sendRequest($request);
-        $this->messages[] = $message;
+        if ($this->storeMessages) {
+            $this->messages[] = $message;
+        }
 
         $this->logMessage($message);
 
@@ -175,6 +184,16 @@ abstract class BaseClient implements ClientInterface
     public function getMessages(): array
     {
         return $this->messages;
+    }
+
+    /**
+     * Clears the store of Message objects
+     *
+     * @return void
+     */
+    public function clearMesssages(): void
+    {
+        $this->messages = [];
     }
 
     public function getHost(): string

--- a/tests/Unit/Api/BaseClientTest.php
+++ b/tests/Unit/Api/BaseClientTest.php
@@ -228,4 +228,45 @@ class BaseClientTest extends TestCase
             $request->getHeaderLine('X-Contentful-User-Agent')
         );
     }
+
+    public function testClearMessages()
+    {
+        $logger = null;
+        $httpClient = $this->createHttpClient();
+        $client = new Client('b4c0n73n7fu1', 'https://cdn.contentful.com/', $logger, $httpClient);
+        $client->setApplication('sdk-test-application', '1.0');
+
+        $client->callApi('GET', '/spaces/cfexampleapi');
+        $this->assertNotEmpty($client->getMessages());
+        $client->clearMesssages();
+        $this->assertEmpty($client->getMessages());
+    }
+
+    /**
+     * @dataProvider storingMessagesProvider
+     */
+    public function testStoringMessages($storeMessages, $expectedCount)
+    {
+        $logger = null;
+        $httpClient = $this->createHttpClient();
+        $client = new Client('b4c0n73n7fu1', 'https://cdn.contentful.com/', $logger, $httpClient, $storeMessages);
+        $client->setApplication('sdk-test-application', '1.0');
+
+        $client->callApi('GET', '/spaces/cfexampleapi');
+        $this->assertCount($expectedCount, $client->getMessages());
+    }
+
+    public function storingMessagesProvider()
+    {
+        return [
+            'false' => [
+                'storeMessages' => false,
+                'expectedCount' => 0,
+            ],
+            'true' => [
+                'storeMessages' => true,
+                'expectedCount' => 1,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
BaseClient stores each API response, which is useful for debugging. However, if many API requests are made
or a long-running CLI script then this can lead to excessive memory consumption.
Two mechanisms have been added to help with this:
- `BaseClient::clearMessages()` method added to allow wiping the message storage
- `BaseClient::__construct` has an optional parameter, `$storeMessages`, which disables the storing of messages completely.