### PR TITLE
Add generics notation to ResourceArray class

### DIFF
--- a/src/Resource/ResourceArray.php
+++ b/src/Resource/ResourceArray.php
@@ -19,6 +19,8 @@ use Contentful\Core\Api\Link;
  *
  * In addition to the retrieved items themselves
  * it also provides some access to metadata.
+ *
+ * @implements \IteratorAggregate<int, \Contentful\Core\Resource\ResourceInterface>
  */
 class ResourceArray implements ResourceInterface, \Countable, \ArrayAccess, \IteratorAggregate
 {


### PR DESCRIPTION
This resolves the following PHPStan errors in consuming code:

```
Method App\ContentfulService::buildContentfulEntries() has parameter $entries with no value type specified
in iterable type Contentful\Core\Resource\ResourceArray.
💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
```