### PR TITLE
Added php8 support (release 3.1.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,12 +12,14 @@ workflows:
       - test72
       - test73
       - test74
+      - test80
       - docs_build:
           requires:
             - lint
             - test72
             - test73
             - test74
+            - test80
           filters:
             branches:
               only: master
@@ -68,7 +70,7 @@ jobs:
       - checkout
       - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist" }
       - run: { name: "Test suite", command: "composer test-quick-fail" }
-        
+
   test74:
     docker:
       - image: circleci/php:7.4-cli
@@ -76,7 +78,15 @@ jobs:
       - checkout
       - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist" }
       - run: { name: "Test suite", command: "composer test-quick-fail" }
-        
+
+  test80:
+    docker:
+      - image: circleci/php:8.0-cli
+    steps:
+      - checkout
+      - run: { name: "Install dependencies", command: "sudo composer self-update && composer install -n --prefer-dist" }
+      - run: { name: "Test suite", command: "composer test-quick-fail" }
+
   docs_build:
     environment:
       TRAVIS_REPO_SLUG: contentful/contentful-core.php

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@
 /.php_cs.cache
 /clover.xml
 /phpstan.phar
+/.idea/
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Requirements
 
-This package requires PHP 7.2 or above.
+This package requires PHP 7.2 or above or PHP 8.0 or above.
 
 ## About
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Foundation library for Contentful PHP SDKs",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0",


### PR DESCRIPTION
This commit adds PHP8 support to the contentful core. It does the
following:
- Bump the version to 3.1.0 (new minor)
- Add a php8 image to the CI to run the tests on php8
- Allow PHP8 in composer.json

The code was verified against the official breaking changes guide [0].
Note that code coverage is not yet supported by phpunit on php8. As it
should be pretty much the same as on older PHP versions, however, this
is accepted for now.

[0] https://www.php.net/manual/en/migration80.php

This replaces #46 (not possible to change the target branch and this enables a `-dev`-release first) and #44 (no CI integration). Will be merged once the code is tested with other repos.