### PR TITLE
Account for not provided fileName and contentType received from API

### DIFF
--- a/src/File/LocalUploadFile.php
+++ b/src/File/LocalUploadFile.php
@@ -19,12 +19,12 @@ use Contentful\Core\Api\Link;
 class LocalUploadFile implements UnprocessedFileInterface
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $fileName;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $contentType;
 
@@ -33,7 +33,7 @@ class LocalUploadFile implements UnprocessedFileInterface
      */
     private $uploadFrom;
 
-    public function __construct(string $fileName, string $contentType, Link $uploadFrom)
+    public function __construct(?string $fileName, ?string $contentType, Link $uploadFrom)
     {
         $this->fileName = $fileName;
         $this->contentType = $contentType;
@@ -45,7 +45,7 @@ class LocalUploadFile implements UnprocessedFileInterface
      */
     public function getFileName(): string
     {
-        return $this->fileName;
+        return $this->fileName ?? '';
     }
 
     /**
@@ -53,7 +53,7 @@ class LocalUploadFile implements UnprocessedFileInterface
      */
     public function getContentType(): string
     {
-        return $this->contentType;
+        return $this->contentType ?? '';
     }
 
     public function getUploadFrom(): Link

--- a/src/File/RemoteUploadFile.php
+++ b/src/File/RemoteUploadFile.php
@@ -17,12 +17,12 @@ namespace Contentful\Core\File;
 class RemoteUploadFile implements UnprocessedFileInterface
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $fileName;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $contentType;
 
@@ -34,7 +34,7 @@ class RemoteUploadFile implements UnprocessedFileInterface
     /**
      * RemoteUploadFile constructor.
      */
-    public function __construct(string $fileName, string $contentType, string $upload)
+    public function __construct(?string $fileName, ?string $contentType, string $upload)
     {
         $this->fileName = $fileName;
         $this->contentType = $contentType;
@@ -46,7 +46,7 @@ class RemoteUploadFile implements UnprocessedFileInterface
      */
     public function getFileName(): string
     {
-        return $this->fileName;
+        return $this->fileName ?? '';
     }
 
     /**
@@ -54,7 +54,7 @@ class RemoteUploadFile implements UnprocessedFileInterface
      */
     public function getContentType(): string
     {
-        return $this->contentType;
+        return $this->contentType ?? '';
     }
 
     public function getUpload(): string


### PR DESCRIPTION
To address issue in #48 I have changed constructor signatures of unprocessed upload classes.
Other solution would be to add validations in Asset creation API to prevent such state from occurring.