### PR TITLE
Do not force image format if quality given

### DIFF
--- a/src/File/ImageOptions.php
+++ b/src/File/ImageOptions.php
@@ -84,11 +84,8 @@ class ImageOptions implements UrlOptionsInterface
             'r' => $this->radius,
         ];
 
-        if (\null !== $this->quality || $this->progressive) {
-            $options['fm'] = 'jpg';
-        }
-
         if ($this->progressive) {
+            $options['fm'] = 'jpg';            
             $options['fl'] = 'progressive';
         }
 


### PR DESCRIPTION
Currently, if quality is set on ImageOptions then the `jpg` format is forced. This any non `jpg` image is converted to `jpg`.
The official [Contentful Images API](https://www.contentful.com/developers/docs/references/images-api/#/reference/image-manipulation/quality) doc says:

> You can alter the quality of the image, expressed as a percentage value between 1 and 100. Quality value is only ignored for 8-bit PNGs.

So the quality parameter could be always passed, it will be ignored automatically by Contentful when not applicable.