### PR TITLE
Add Entry public methods to the Entryinterface

### DIFF
--- a/src/Resource/EntryInterface.php
+++ b/src/Resource/EntryInterface.php
@@ -13,4 +13,15 @@ namespace Contentful\Core\Resource;
 
 interface EntryInterface extends ResourceInterface
 {
+    public function has(string $name, string $locale = null, bool $checkLinksAreResolved = true): bool;
+
+    public function all(string $locale = null, bool $resolveLinks = true, bool $ignoreLocaleForNonLocalizedFields = false): array;
+
+    public function isFieldLocalized(string $name): bool;
+
+    public function get(string $name, string $locale = null, bool $resolveLinks = true);
+
+    public function initTags(array $tags);
+
+    public function getTags(): array;
 }


### PR DESCRIPTION
I think that every implementation should have a proper Interface with public methods declared in it.

## Use case

```php
interface BookInterface
{
    public function getTitle(): string;

    public function getAuthor(): string;

    public function getIsin(): string;
}

final class Book implements BookInterface
{
    public function __construct(
        private string $title,
        private string $title,
        private string $isin
    ) {
    }

    public function getTitle(): string
    {
        return $this->title;
    }

    public function getAuthor(): string
    {
        return $this->author;
    }

    public function getIsin(): string
    {
        return $this->isin;
    }
}

interface BookFactoryInterface
{
    public function createFromEntry(EntryInterface $entry): BookInterface;
}
```

Without my addictions

```php
final class BookFactory implements BookFactoryInterface
{
    public function createFromEntry(EntryInterface $entry): BookInterface
    {
        \Webmozart\Assert\Assert::isInstanceOf($entry, \Contentful\Delivery\Resource\Entry::class);

        return new Book(
            $entry->get('title'),
            $entry->get('author'),
            $entry->get('isin')
        );
    }
}
```

Whit it

```php
final class BookFactory implements BookFactoryInterface
{
    public function createFromEntry(EntryInterface $entry): BookInterface
    {
        return new Book(
            $entry->get('title'),
            $entry->get('author'),
            $entry->get('isin')
        );
    }
}
```

I do not want to declare as an argument of the interface method `createFromEntry` an implementation class as `\Contentful\Delivery\Resource\Entry`. It is a conceptual error, see [Dependency inversion principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle).

```php
interface BookFactoryInterface
{
    public function createFromEntry(Entry $entry): BookInterface;
}
```