### PR TITLE
Allow guzzlehttp/psr7 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.5|^7.0",
-        "guzzlehttp/psr7": "^1.5|^1.6",
+        "guzzlehttp/psr7": "^1.5|^1.6|^2.0",
         "psr/http-message": "^1.0",
         "psr/log": "^1.1|^2.0|^3.0",
         "jean85/pretty-package-versions": "^1.5"

--- a/src/Api/Exception.php
+++ b/src/Api/Exception.php
@@ -12,10 +12,8 @@ declare(strict_types=1);
 namespace Contentful\Core\Api;
 
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Message as GuzzleMessage;
 use function GuzzleHttp\json_decode as guzzle_json_decode;
-use function GuzzleHttp\Psr7\parse_request as guzzle_parse_request;
-use function GuzzleHttp\Psr7\parse_response as guzzle_parse_response;
-use function GuzzleHttp\Psr7\str as guzzle_stringify_message;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -75,8 +73,8 @@ class Exception extends \RuntimeException implements \Serializable
             'file' => $this->message,
             'line' => $this->line,
             'requestId' => $this->requestId,
-            'request' => guzzle_stringify_message($this->request),
-            'response' => $this->response ? guzzle_stringify_message($this->response) : null,
+            'request' => GuzzleMessage::toString($this->request),
+            'response' => $this->response ? GuzzleMessage::toString($this->response) : null,
         ]);
     }
 
@@ -92,8 +90,8 @@ class Exception extends \RuntimeException implements \Serializable
         $this->file = $data['file'];
         $this->line = $data['line'];
         $this->requestId = $data['requestId'];
-        $this->request = guzzle_parse_request($data['request']);
-        $this->response = $data['response'] ? guzzle_parse_response($data['response']) : null;
+        $this->request = GuzzleMessage::parseRequest($data['request']);
+        $this->response = $data['response'] ? GuzzleMessage::parseResponse($data['response']) : null;
     }
 
     private static function createExceptionMessage(

--- a/src/Api/Message.php
+++ b/src/Api/Message.php
@@ -13,9 +13,7 @@ namespace Contentful\Core\Api;
 
 use function GuzzleHttp\json_decode as guzzle_json_decode;
 use function GuzzleHttp\json_encode as guzzle_json_encode;
-use function GuzzleHttp\Psr7\parse_request as guzzle_parse_request;
-use function GuzzleHttp\Psr7\parse_response as guzzle_parse_response;
-use function GuzzleHttp\Psr7\str as guzzle_stringify_message;
+use GuzzleHttp\Psr7\Message as GuzzleMessage;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LogLevel;
@@ -94,8 +92,8 @@ class Message implements \Serializable, \JsonSerializable
         return new self(
             $data['api'],
             $data['duration'],
-            guzzle_parse_request($data['request']),
-            $data['response'] ? guzzle_parse_response($data['response']) : null,
+            GuzzleMessage::parseRequest($data['request']),
+            $data['response'] ? GuzzleMessage::parseResponse($data['response']) : null,
             $data['exception'] ? \unserialize($data['exception']) : null
         );
     }
@@ -154,8 +152,8 @@ class Message implements \Serializable, \JsonSerializable
         return [
             'api' => $this->api,
             'duration' => $this->duration,
-            'request' => guzzle_stringify_message($this->request),
-            'response' => null !== $this->response ? guzzle_stringify_message($this->response) : null,
+            'request' => GuzzleMessage::toString($this->request),
+            'response' => null !== $this->response ? GuzzleMessage::toString($this->response) : null,
             'exception' => \serialize($this->exception),
         ];
     }
@@ -185,7 +183,7 @@ class Message implements \Serializable, \JsonSerializable
 
         $this->api = $data['api'];
         $this->duration = $data['duration'];
-        $this->request = guzzle_parse_request($data['request']);
+        $this->request = GuzzleMessage::parseRequest($data['request']);
         $this->response = null !== $data['response'] ? guzzle_parse_response($data['response']) : null;
         $this->exception = \unserialize($data['exception']);
     }

--- a/tests/Unit/Api/BaseClientTest.php
+++ b/tests/Unit/Api/BaseClientTest.php
@@ -23,8 +23,7 @@ use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
-use function GuzzleHttp\Psr7\parse_request as guzzle_parse_request;
-use function GuzzleHttp\Psr7\parse_response as guzzle_parse_response;
+use GuzzleHttp\Psr7\Message as GuzzleMessage;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -76,9 +75,9 @@ class BaseClientTest extends TestCase
         $this->assertNull(\unserialize($context['exception']));
 
         try {
-            $request = guzzle_parse_request($context['request']);
+            $request = GuzzleMessage::parseRequest($context['request']);
             if ($context['response']) {
-                $response = guzzle_parse_response($context['response']);
+                $response = GuzzleMessage::parseResponse($context['response']);
                 $this->assertSame(200, $response->getStatusCode());
             }
         } catch (\Exception $exception) {


### PR DESCRIPTION
I have a third party package that requires  guzzlehttp/psr7 2.x. However, contentful/core requires guzzlehttp/psr7 1.x, so I can't have both Contentful and the third party package installed at the same time.

This PR updates contentful/core to work with either psr7 1.x or 2.x by updating usages of the psr7 helpers which were removed in psr7 2.0.