### PR TITLE
chore: route CI alerts to sdk-bots channel [DX-687]

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     github.com/project-slug: contentful/contentful-core.php 
     contentful.com/service-tier: "4"
+    contentful.com/ci-alert-slack: sdk-bots
   tags:
     - tier-4
 spec:


### PR DESCRIPTION
Routes CI alerts to #sdk-bots Slack channel by adding the contentful.com/ci-alert-slack annotation to catalog-info.yaml.